### PR TITLE
Configure the README example runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ invalidations are stored in the database the application already operates.
 ## The programming model
 
 ```typescript
-import { Actor } from "solid-objects"
+import { Actor, createRuntime } from "solid-objects"
+import { sqlite } from "solid-objects/database/sqlite"
 
 class Cart extends Actor {
   static override readonly actorType = "Cart"
@@ -34,8 +35,20 @@ class Cart extends Actor {
   }
 }
 
-const cart = Cart.ref("cart-123")
-await Promise.all([cart.add({ sku: "blue-shirt" }), cart.add({ sku: "green-hat" })])
+const runtime = createRuntime({
+  database: sqlite({ path: "cart.sqlite3" }),
+  authorizeMessage: () => true,
+  authorizeQuery: () => true,
+})
+
+await runtime.install()
+
+try {
+  const cart = runtime.ref(Cart, "cart-123")
+  await Promise.all([cart.add({ sku: "blue-shirt" }), cart.add({ sku: "green-hat" })])
+} finally {
+  await runtime.close()
+}
 ```
 
 Both calls enter the durable mailbox for `cart-123`. They execute in order and


### PR DESCRIPTION
## Summary

- create an explicit SQLite runtime before constructing the Cart reference
- use the isolated `runtime.ref()` API instead of relying on an unconfigured process default
- install and close the runtime so the opening TypeScript example is executable as written

## Validation

- `pnpm run format:check`
- `pnpm run check`
- `pnpm run test:package`
- clean temporary project using the published `solid-objects@0.13.0` package: concurrent calls returned `[1, 2]` and the final committed item count was `2`