### PR TITLE
fix: expose process liveness query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.2 - 2026-08-16
+
+- Add an authorized `runtime.administration.processes()` query for inspecting
+  live and stale process rows through the runtime's database adapter.
+- Document rolling-deployment overlap as a reason for the polling-only warning.
+
 ## 0.13.1 - 2026-08-16
 
 - Back idle actor, effect, reminder, and broadcast polling off exponentially

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ processes submit them concurrently.
 
 ## Run it now with SQLite
 
-Node.js 24.15 or newer is required. The `0.13.1` release includes a
+Node.js 24.15 or newer is required. The `0.13.2` release includes a
 packaged quickstart:
 
 ```bash
-npm exec --yes --package=solid-objects@0.13.1 -- solid-objects quickstart
+npm exec --yes --package=solid-objects@0.13.2 -- solid-objects quickstart
 ```
 
 The command needs no repository checkout, database server, Redis, container, or

--- a/README.md
+++ b/README.md
@@ -76,6 +76,28 @@ local run, it verifies that:
 - operations for two different identities overlap in time; and
 - the runtime closes and temporary state is removed.
 
+## What Solid Objects is for
+
+Use Solid Objects when more than one request, job, or process can act on the
+same logical thing and the next action must use its latest committed state.
+These are the stateful coordination patterns for which people often reach for
+Durable Objects:
+
+| Pattern                                 | One identity per              | What the object coordinates                                                                 |
+| --------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
+| Multiplayer, presence, or collaboration | Room, session, or document    | Joins, moves, and edits commit in order; subscribers refresh from committed state           |
+| Reservations and expiring holds         | Show, resource, or stock item | Availability checks and holds cannot interleave; a durable reminder can release an old hold |
+| Checkout and account workflows          | Cart, order, account, device  | The current step, retries, and effect results return to the same ordered mailbox            |
+| Per-key rate limits                     | API key, account, or device   | Token checks and decrements are serialized; a reminder can refill the bucket                |
+| Stateful agent sessions                 | Agent session                 | Messages and tool results apply in order and pending work survives a worker exit            |
+
+The common shape is one durable coordination boundary with an application
+defined identity. Work for that identity is serialized, while unrelated rooms,
+carts, accounts, or sessions can progress concurrently. A single global rate
+limiter or another very hot identity is a poor fit because it becomes an
+intentional bottleneck. If one ordinary row transaction solves the problem,
+prefer that. See [Choosing Solid Objects](docs/fit.md) for the longer guide.
+
 ## Running in a deployed application
 
 [Shuffle Up and Play](https://shuffleupandplay.com/) is a deployed reference
@@ -110,28 +132,6 @@ and multi-process lease fencing are verified separately by the library's
 [failure-recovery demonstration](examples/failure-recovery/demo.ts), and
 [correctness contract](docs/correctness.md). Evaluate those guarantees and
 limits against your own workload.
-
-## What Solid Objects is for
-
-Use Solid Objects when more than one request, job, or process can act on the
-same logical thing and the next action must use its latest committed state.
-These are the stateful coordination patterns for which people often reach for
-Durable Objects:
-
-| Pattern                                 | One identity per              | What the object coordinates                                                                 |
-| --------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
-| Multiplayer, presence, or collaboration | Room, session, or document    | Joins, moves, and edits commit in order; subscribers refresh from committed state           |
-| Reservations and expiring holds         | Show, resource, or stock item | Availability checks and holds cannot interleave; a durable reminder can release an old hold |
-| Checkout and account workflows          | Cart, order, account, device  | The current step, retries, and effect results return to the same ordered mailbox            |
-| Per-key rate limits                     | API key, account, or device   | Token checks and decrements are serialized; a reminder can refill the bucket                |
-| Stateful agent sessions                 | Agent session                 | Messages and tool results apply in order and pending work survives a worker exit            |
-
-The common shape is one durable coordination boundary with an application
-defined identity. Work for that identity is serialized, while unrelated rooms,
-carts, accounts, or sessions can progress concurrently. A single global rate
-limiter or another very hot identity is a poor fit because it becomes an
-intentional bottleneck. If one ordinary row transaction solves the problem,
-prefer that. See [Choosing Solid Objects](docs/fit.md) for the longer guide.
 
 ## How it works
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -89,6 +89,9 @@ class and result types are also exported for integration typing.
   idempotent paused-alarm `resume()`.
 - `runtime.processes` / `ProcessManager`: immutable role `all()` and stale-owner
   `cleanup()`.
+- `runtime.administration` / `AdministrationManager`: an authorized
+  `processes()` query for inspecting live and stale process rows through the
+  runtime's own database adapter.
 - `runtime.reconciliation` / `ReconciliationManager`: `active()`,
   `withoutPendingWork()`, `statesFor()`, and `orphaned()` bounded reads.
 - `runtime.retention` / `RetentionManager`: `preview()` and authorized `prune()`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -17,6 +17,14 @@ delivery; without one, newly committed work can wait up to the current idle
 polling interval. Notification errors are isolated and logged by role and error
 class without failing the committed work.
 
+The warning excludes process rows with the current hostname and host process ID.
+It can therefore appear during a rolling deployment or restart overlap when an
+older and newer process briefly share the same database. A process that stopped
+without graceful cleanup remains live until its heartbeat exceeds
+`processAliveThresholdMilliseconds`; inspect
+`runtime.administration.processes()` to distinguish a live overlap from a stale
+row.
+
 Each role exposes `currentPollingIntervalMilliseconds`.
 `solid_objects.polling.interval_changed` reports the role, reason, previous
 interval, and current interval. The polling-only warning is also emitted as
@@ -62,9 +70,12 @@ runs under the application-write guard, and `onDeactivate()` is best effort:
 it may not run after a crash, cannot establish a correctness guarantee, and a
 failure is logged without preventing lease release.
 
-`runtime.processes.all()` returns administration-authorized immutable process
-metadata with hostname, host process ID, Node and Solid Objects versions, and a
-current `stale` flag. Graceful shutdown first persists `draining` with a
+`runtime.administration.processes()` returns the same administration-authorized
+immutable process metadata as `runtime.processes.all()`, with hostname, host
+process ID, Node and Solid Objects versions, and a current `stale` flag. It is
+safe to call through the runtime's database adapter while workers are running;
+the query is serialized with other database access and does not require a
+second SQLite connection. Graceful shutdown first persists `draining` with a
 `shutdownRequestedAt` timestamp, then deactivates owned actors and atomically
 releases every role claim before persisting `stopped`. `cleanup()` reauthorizes
 separately and performs the same release for stale running or draining

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -4,11 +4,11 @@ This ledger tracks capability parity with the Ruby `solid_objects` gem.
 Parity means preserving a capability and its correctness or security boundary,
 not copying a Rails API into Node.
 
-Reference: Ruby `solid_objects` 0.13.1. The JavaScript package began at the
+Reference: Ruby `solid_objects` 0.13.2. The JavaScript package began at the
 Ruby design's `0.12` capability generation; that version number did not imply
 earlier JavaScript releases.
 
-The Node `0.13.1` implementation has capability parity with that reference. Its
+The Node `0.13.2` implementation has capability parity with that reference. Its
 relational runtime, correctness boundaries, administration, diagnostics,
 operator dashboard, realtime projections, browser behavior, and supported
 adapters have native equivalents. Rails-specific rendering surfaces are

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -38,8 +38,8 @@ npm trust github solid-objects \
 4. Create and push an annotated tag matching the package version:
 
    ```shell
-   git tag -a v0.13.1 -m "Version 0.13.1"
-   git push origin v0.13.1
+   git tag -a v0.13.2 -m "Version 0.13.2"
+   git push origin v0.13.2
    ```
 
 The tag runs the complete CI matrix. The publish job starts only after every

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-objects",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Race-free realtime state per application identity, backed by your SQL database",
   "type": "module",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export {
 } from "./realtime.js"
 export { DeadLetterManager, type DeadLetter } from "./dead-letters.js"
 export {
+  AdministrationManager,
   ProcessManager,
   type ProcessCleanupResult,
   type ProcessMetadata,

--- a/src/process-administration.ts
+++ b/src/process-administration.ts
@@ -26,6 +26,14 @@ export interface ProcessCleanupResult {
   readonly cleaned: number
 }
 
+export class AdministrationManager {
+  constructor(private readonly runtime: SolidObjectsRuntime) {}
+
+  processes(options: AdministrationOptions = {}): Promise<readonly ProcessRecord[]> {
+    return this.runtime.inspectProcesses(options)
+  }
+}
+
 export class ProcessManager {
   constructor(private readonly runtime: SolidObjectsRuntime) {}
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -66,6 +66,7 @@ import {
 } from "./reconciliation.js"
 import { Repository } from "./repository.js"
 import {
+  AdministrationManager,
   ProcessManager,
   type ProcessCleanupResult,
   type ProcessMetadata,
@@ -158,6 +159,7 @@ export class SolidObjectsRuntime {
   readonly reminders
   readonly realtime
   readonly processes
+  readonly administration
   private readonly registry = new Map<string, RegisteredActor>()
   private readonly effects = new Map<string, EffectHandler>()
   private readonly commitActions = new Map<string, CommitActionHandler>()
@@ -178,6 +180,7 @@ export class SolidObjectsRuntime {
     this.reminders = new ReminderManager(this)
     this.realtime = new RealtimeManager(this)
     this.processes = new ProcessManager(this)
+    this.administration = new AdministrationManager(this)
   }
 
   async install(): Promise<void> {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.13.1"
+export const VERSION = "0.13.2"

--- a/test/polling-loop.test.ts
+++ b/test/polling-loop.test.ts
@@ -260,6 +260,7 @@ describe("idle polling", () => {
       warn: vi.fn(),
       error: vi.fn(),
     }
+    const events: InstrumentationEvent[] = []
     runtime = createRuntime({
       database: sqlite({ path: ":memory:" }),
       pollingIntervalMilliseconds: 25,
@@ -269,6 +270,7 @@ describe("idle polling", () => {
       retentionIntervalMilliseconds: 0,
       deadProcessCleanupIntervalMilliseconds: 0,
       logger,
+      instrumentation: (event) => events.push(event),
     })
     await runtime.install()
     await runtime.repository.registerProcess("other-process", "worker")
@@ -298,6 +300,39 @@ describe("idle polling", () => {
       pollingIntervalMilliseconds: 25,
       idlePollingIntervalMilliseconds: 1_000,
     })
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        name: "solid_objects.polling.only_cross_process_wake_up",
+        attributes: {
+          pollingIntervalMilliseconds: 25,
+          idlePollingIntervalMilliseconds: 1_000,
+        },
+      }),
+    )
+  })
+
+  it("does not warn when all observed processes share the current host process", async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }
+    runtime = createRuntime({
+      database: sqlite({ path: ":memory:" }),
+      workerCount: 1,
+      effectWorkerCount: 0,
+      reminderSchedulerCount: 0,
+      retentionIntervalMilliseconds: 0,
+      deadProcessCleanupIntervalMilliseconds: 0,
+      logger,
+    })
+    await runtime.install()
+    await runtime.repository.registerProcess("same-process", "worker")
+
+    await runtime.warnIfPollingIsOnlyCrossProcessWakeUp()
+
+    expect(logger.warn).not.toHaveBeenCalled()
   })
 
   it("does not warn when a cross-process wake-up adapter is configured", async () => {

--- a/test/process-administration.test.ts
+++ b/test/process-administration.test.ts
@@ -26,6 +26,13 @@ describe("process administration", () => {
     await expect(runtime.processes.all()).rejects.toBeInstanceOf(Unauthorized)
   })
 
+  it("authorizes the administration process query", async () => {
+    runtime = configuredRuntime({ authorizeAdministration: () => false })
+    await runtime.install()
+
+    await expect(runtime.administration.processes()).rejects.toBeInstanceOf(Unauthorized)
+  })
+
   it("returns immutable process metadata with current liveness", async () => {
     runtime = configuredRuntime()
     await runtime.install()
@@ -56,6 +63,24 @@ describe("process administration", () => {
     expect(Object.isFrozen(processes)).toBe(true)
     expect(processes.every(Object.isFrozen)).toBe(true)
     expect(processes.every(({ metadata }) => Object.isFrozen(metadata))).toBe(true)
+  })
+
+  it("exposes process liveness through the administration query", async () => {
+    runtime = configuredRuntime()
+    await runtime.install()
+    await runtime.repository.registerProcess("live", "worker")
+
+    const processes = await runtime.administration.processes()
+
+    expect(processes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "live",
+          kind: "worker",
+          stale: false,
+        }),
+      ]),
+    )
   })
 
   it("atomically releases every claim owned by a stale process", async () => {

--- a/test/process-administration.test.ts
+++ b/test/process-administration.test.ts
@@ -49,7 +49,7 @@ describe("process administration", () => {
       hostProcessId: process.pid,
       metadata: {
         nodeVersion: process.version,
-        solidObjectsVersion: "0.13.1",
+        solidObjectsVersion: "0.13.2",
       },
       shutdownState: "running",
       shutdownRequestedAt: null,


### PR DESCRIPTION
## Summary

- add `runtime.administration.processes()` for authorized process inspection
- cover same-process rows, cross-process warning attributes, at-most-once emission, and authorization
- document rolling-deployment overlap and stale-heartbeat behavior

## Root cause

The warning is evidence-based. `src/runtime.ts` checks `hasLiveProcessOutsideCurrentHostProcess()`, so it only fires when a live process row has a different host or PID. A single runtime's component rows share the current host and PID and do not trigger it. A rolling deployment or uncleanly stopped process can legitimately leave a second live row during the liveness window.

The new administration query uses the existing runtime database adapter, avoiding a competing SQLite connection while workers are active.

## Verification

- `pnpm run check`
- `pnpm run format:check`
- `pnpm run test:coverage` — 230 passed, 11 skipped
- `pnpm run build`
- `pnpm run test:package`
- `pnpm run test:recovery`
- `pnpm run test:browser` — 3 passed
