### PR TITLE
Let a reminder be named for the item it waits on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   others alone. Without a key the name is still the operation, so existing
   reminders keep their names and their coalescing behaviour. Adds a nullable
   `message_operation` column to the reminders table, left null on existing rows.
+  The composed name is bounded by the 255 characters MySQL holds it in, checked
+  on the name rather than the key alone.
 
 ## 0.13.2 - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Accept a `key` on `schedule`, naming a reminder for the item it is waiting
+  on rather than for its operation, so one actor can hold an alarm per queued
+  item. Scheduling the same key again moves that item's alarm and leaves the
+  others alone. Without a key the name is still the operation, so existing
+  reminders keep their names and their coalescing behaviour. Adds a nullable
+  `message_operation` column to the reminders table, left null on existing rows.
+
 ## 0.13.2 - 2026-08-16
 
 - Add an authorized `runtime.administration.processes()` query for inspecting

--- a/docs/api.md
+++ b/docs/api.md
@@ -108,7 +108,12 @@ add({ entry }: { entry: Entry }): void {
 
 Scheduling the same key again moves that item's alarm and leaves the others
 alone. The operation still decides which handler runs; the key only decides
-which alarm is which. A key must be non-empty and at most 128 characters.
+which alarm is which.
+
+A key must be non-empty, and the name it composes must fit the 255 characters
+MySQL holds it in. That is checked on the composed name rather than the key
+alone, so a long operation with a short key is caught too. A key may hold colons
+of its own, because an actor member name cannot.
 
 An actor that only needs to know "what is next" can still keep one alarm and
 drain everything due when it fires. That costs one row instead of one per item

--- a/docs/api.md
+++ b/docs/api.md
@@ -79,6 +79,43 @@ function playerForSession<PlayerType extends { sessionId: string }>(options: {
 }
 ```
 
+### Reminders
+
+A reminder is one alarm per actor and name. Scheduling a name that is already
+armed **moves the existing alarm** rather than adding a second one, which is
+what makes a reminder safe to re-arm from a handler that may run more than once.
+
+Without a key that name is the operation, so one actor holds one alarm per
+operation, and arming one per queued item keeps only the last:
+
+```typescript
+// Wrong. Every entry overwrites the previous entry's alarm.
+add({ entry }: { entry: Entry }): void {
+  this.entries = [...this.entries, entry]
+  this.schedule({ at: new Date(entry.waitUntil) }).deliver!()
+}
+```
+
+Pass `key` when an actor is waiting on several things at once. The key is your
+own identifier for the item and names that item's alarm, so each item gets one:
+
+```typescript
+add({ entry }: { entry: Entry }): void {
+  this.entries = [...this.entries, entry]
+  this.schedule({ at: new Date(entry.waitUntil), key: entry.id }).deliver!()
+}
+```
+
+Scheduling the same key again moves that item's alarm and leaves the others
+alone. The operation still decides which handler runs; the key only decides
+which alarm is which. A key must be non-empty and at most 128 characters.
+
+An actor that only needs to know "what is next" can still keep one alarm and
+drain everything due when it fires. That costs one row instead of one per item
+and cannot strand an entry when an occurrence is coalesced, so prefer it for a
+large queue of interchangeable items and prefer `key` when an item needs an
+alarm that can be moved on its own.
+
 ### Runtime managers
 
 Every manager below is available as a property on `SolidObjectsRuntime`; the

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -57,7 +57,7 @@ export interface CommitActionIntent {
 }
 
 export interface ReminderIntent {
-  /** Names the alarm. Without a key this is the operation. */
+  /** Without a key this is the operation. */
   name: string
   operation: string
   atMilliseconds: number
@@ -94,30 +94,43 @@ export interface ReminderOptions {
   at: Date
   everyMilliseconds?: number
   missed?: "all" | "latest"
-  /**
-   * Your own identifier for the item this alarm is waiting on. Give one when an
-   * actor waits on several things at once, so each gets its own alarm.
-   */
+  /** Your own identifier for the item this alarm waits on, so each item gets one. */
   key?: string | number
 }
 
-/**
- * The key becomes part of the reminder name, which the database holds alongside
- * the operation, so it is bounded here rather than failing on the insert once
- * the turn is already doing work.
- */
-const REMINDER_KEY_LIMIT = 128
+/** MySQL holds the reminder name in a VARCHAR(255); the other families hold more. */
+const REMINDER_NAME_LIMIT = 255
+const REMINDER_KEY_SEPARATOR = ":"
 
 function validatedReminderKey(key: string | number | undefined): string | undefined {
   if (key === undefined) return undefined
 
   const reminderKey = String(key)
   if (reminderKey.length === 0) throw new TypeError("reminder key must not be empty")
-  if (reminderKey.length > REMINDER_KEY_LIMIT) {
-    throw new TypeError(`reminder key must be at most ${REMINDER_KEY_LIMIT} characters`)
-  }
 
   return reminderKey
+}
+
+/**
+ * The name is the operation, a colon, and the key. An operation cannot hold a
+ * colon of its own, so a keyed name never collides with an unkeyed one.
+ *
+ * The length is checked on the composed name rather than the key alone, because
+ * a long operation and a short key overflow the column just as easily as the
+ * reverse, and it is refused here rather than at the insert, once the turn is
+ * already doing work.
+ */
+function reminderName(operation: string, key: string | undefined): string {
+  if (key === undefined) return operation
+
+  const name = `${operation}${REMINDER_KEY_SEPARATOR}${key}`
+  if (name.length > REMINDER_NAME_LIMIT) {
+    throw new TypeError(
+      `reminder name ${name.length} characters exceeds the ${REMINDER_NAME_LIMIT} the database holds`,
+    )
+  }
+
+  return name
 }
 
 export interface OutboundMessageOptions {
@@ -213,13 +226,7 @@ export abstract class Actor {
     this.#intents.commitActions.push({ name, arguments: jsonObject(argumentsValue) })
   }
 
-  /**
-   * A reminder is one alarm per actor and name, and without a key that name is
-   * the operation, so one actor holds one alarm per operation. A key names the
-   * alarm for the item it is waiting on, which is what an actor holding a queue
-   * of scheduled work needs; scheduling the same key again moves that item's
-   * alarm and leaves the others alone.
-   */
+  /** See docs/api.md for when to give a reminder a key. */
   schedule(options: ReminderOptions): ScheduledOperations {
     const atMilliseconds = options.at.getTime()
     if (!Number.isFinite(atMilliseconds)) throw new TypeError("reminder time must be valid")
@@ -230,7 +237,7 @@ export abstract class Actor {
 
     return createStagedOperationMap(this.#operations, (operation, argumentsValue) => {
       this.#intents.reminders.push({
-        name: key === undefined ? operation : `${operation}:${key}`,
+        name: reminderName(operation, key),
         operation,
         atMilliseconds,
         arguments: jsonObject(argumentsValue),

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -57,6 +57,8 @@ export interface CommitActionIntent {
 }
 
 export interface ReminderIntent {
+  /** Names the alarm. Without a key this is the operation. */
+  name: string
   operation: string
   atMilliseconds: number
   arguments: JsonObject
@@ -92,6 +94,30 @@ export interface ReminderOptions {
   at: Date
   everyMilliseconds?: number
   missed?: "all" | "latest"
+  /**
+   * Your own identifier for the item this alarm is waiting on. Give one when an
+   * actor waits on several things at once, so each gets its own alarm.
+   */
+  key?: string | number
+}
+
+/**
+ * The key becomes part of the reminder name, which the database holds alongside
+ * the operation, so it is bounded here rather than failing on the insert once
+ * the turn is already doing work.
+ */
+const REMINDER_KEY_LIMIT = 128
+
+function validatedReminderKey(key: string | number | undefined): string | undefined {
+  if (key === undefined) return undefined
+
+  const reminderKey = String(key)
+  if (reminderKey.length === 0) throw new TypeError("reminder key must not be empty")
+  if (reminderKey.length > REMINDER_KEY_LIMIT) {
+    throw new TypeError(`reminder key must be at most ${REMINDER_KEY_LIMIT} characters`)
+  }
+
+  return reminderKey
 }
 
 export interface OutboundMessageOptions {
@@ -187,15 +213,24 @@ export abstract class Actor {
     this.#intents.commitActions.push({ name, arguments: jsonObject(argumentsValue) })
   }
 
+  /**
+   * A reminder is one alarm per actor and name, and without a key that name is
+   * the operation, so one actor holds one alarm per operation. A key names the
+   * alarm for the item it is waiting on, which is what an actor holding a queue
+   * of scheduled work needs; scheduling the same key again moves that item's
+   * alarm and leaves the others alone.
+   */
   schedule(options: ReminderOptions): ScheduledOperations {
     const atMilliseconds = options.at.getTime()
     if (!Number.isFinite(atMilliseconds)) throw new TypeError("reminder time must be valid")
     if (options.everyMilliseconds !== undefined && options.everyMilliseconds <= 0) {
       throw new TypeError("reminder interval must be positive")
     }
+    const key = validatedReminderKey(options.key)
 
     return createStagedOperationMap(this.#operations, (operation, argumentsValue) => {
       this.#intents.reminders.push({
+        name: key === undefined ? operation : `${operation}:${key}`,
         operation,
         atMilliseconds,
         arguments: jsonObject(argumentsValue),

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -75,7 +75,7 @@ const EXPECTED_COLUMNS: Readonly<Record<string, readonly string[]>> = {
     "activation_generation",
     "claimed_at_ms",
   ],
-  reminders: ["id", "instance_id", "operation", "run_at_ms", "status"],
+  reminders: ["id", "instance_id", "operation", "message_operation", "run_at_ms", "status"],
   effects: ["id", "message_id", "instance_id", "name", "status", "available_at_ms"],
   broadcasts: [
     "id",
@@ -202,7 +202,7 @@ export class Doctor {
           message: `incompatible schema identity ${wrongIdentity.schema_identity}`,
         })
       }
-      if (versions.join(",") !== "1,2,3,4,5,6") {
+      if (versions.join(",") !== "1,2,3,4,5,6,7") {
         return check({
           name: "schema",
           status: "fail",

--- a/src/records.ts
+++ b/src/records.ts
@@ -119,6 +119,7 @@ export interface ReminderRow {
   actor_type: string
   actor_id: string
   operation: string
+  message_operation: string | null
   run_at_ms: number | bigint
   arguments: string
   interval_ms: number | bigint | null

--- a/src/reminder-administration.ts
+++ b/src/reminder-administration.ts
@@ -7,9 +7,8 @@ export interface ReminderRecord {
   readonly id: string
   readonly actorType: string
   readonly actorId: string
-  /** Names the alarm. Without a key this is the operation. */
+  /** Without a key this is the operation. */
   readonly name: string
-  /** The message the alarm runs when it comes due. */
   readonly operation: string
   readonly runAt: Date
   readonly intervalMilliseconds: number | null

--- a/src/reminder-administration.ts
+++ b/src/reminder-administration.ts
@@ -7,6 +7,9 @@ export interface ReminderRecord {
   readonly id: string
   readonly actorType: string
   readonly actorId: string
+  /** Names the alarm. Without a key this is the operation. */
+  readonly name: string
+  /** The message the alarm runs when it comes due. */
   readonly operation: string
   readonly runAt: Date
   readonly intervalMilliseconds: number | null

--- a/src/reminder-scheduler.ts
+++ b/src/reminder-scheduler.ts
@@ -49,7 +49,7 @@ export class ReminderScheduler {
           reminderId: reminder.id,
           actorType: reminder.actor_type,
           actorId: reminder.actor_id,
-          operation: reminder.operation,
+          operation: reminder.message_operation ?? reminder.operation,
           error: error.message,
         })
         return 1

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -675,7 +675,7 @@ export class Repository {
         const existing = await connection.get<{ id: string; run_at_ms: number | bigint }>(
           `SELECT id, run_at_ms FROM ${this.table("reminders")}
            WHERE instance_id = ? AND operation = ?`,
-          [turn.instance.id, reminder.operation],
+          [turn.instance.id, reminder.name],
         )
         if (existing && Number(existing.run_at_ms) !== reminder.atMilliseconds) {
           reminderReplacements.push({
@@ -687,14 +687,17 @@ export class Repository {
         }
         await connection.run(
           `INSERT INTO ${this.table("reminders")}
-           (id, instance_id, operation, run_at_ms, arguments, interval_ms, missed_policy, status)
-           VALUES (?, ?, ?, ?, ?, ?, ?, 'scheduled')
+           (id, instance_id, operation, message_operation, run_at_ms, arguments, interval_ms,
+            missed_policy, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'scheduled')
            ON CONFLICT(instance_id, operation) DO UPDATE SET run_at_ms = excluded.run_at_ms,
+             message_operation = excluded.message_operation,
              arguments = excluded.arguments, interval_ms = excluded.interval_ms,
              missed_policy = excluded.missed_policy, status = 'scheduled', error = NULL`,
           [
             randomUUID(),
             turn.instance.id,
+            reminder.name,
             reminder.operation,
             reminder.atMilliseconds,
             JSON.stringify(reminder.arguments),
@@ -1507,7 +1510,7 @@ export class Repository {
       await this.enqueueInTransaction(connection, {
         actorType: claimed.actor_type,
         actorId: claimed.actor_id,
-        operation: claimed.operation,
+        operation: claimed.message_operation ?? claimed.operation,
         deliveryMode: "internal",
         arguments: jsonObject(JSON.parse(claimed.arguments)),
         idempotencyKey: `reminder:${claimed.id}:${claimed.occurrence}`,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1055,7 +1055,7 @@ export class SolidObjectsRuntime {
         reminderId: result.reminder.id,
         actorType: result.reminder.actor_type,
         actorId: result.reminder.actor_id,
-        operation: result.reminder.operation,
+        operation: result.reminder.message_operation ?? result.reminder.operation,
         runAt: new Date(Number(result.reminder.run_at_ms)).toISOString(),
       })
       this.wakeUp("reminders")
@@ -1404,8 +1404,9 @@ export class SolidObjectsRuntime {
     options: { nowMilliseconds?: number } = {},
   ): Promise<void> {
     const actor = this.fetchActor(reminder.actor_type)
-    if (!actor.operations.has(reminder.operation)) {
-      throw new UnknownOperation(`unknown reminder operation ${JSON.stringify(reminder.operation)}`)
+    const dispatchOperation = reminder.message_operation ?? reminder.operation
+    if (!actor.operations.has(dispatchOperation)) {
+      throw new UnknownOperation(`unknown reminder operation ${JSON.stringify(dispatchOperation)}`)
     }
     await this.repository.enqueueReminder(reminder, options)
     this.wakeUp("actors")
@@ -2079,7 +2080,8 @@ function reminderRecord(row: ReminderRow): ReminderRecord {
     id: row.id,
     actorType: row.actor_type,
     actorId: row.actor_id,
-    operation: row.operation,
+    name: row.operation,
+    operation: row.message_operation ?? row.operation,
     runAt: new Date(Number(row.run_at_ms)),
     intervalMilliseconds: row.interval_ms === null ? null : Number(row.interval_ms),
     missedPolicy: row.missed_policy,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -7,7 +7,8 @@ const MESSAGE_IDENTITY_VERSION = 3
 const PROCESS_IDENTITY_VERSION = 4
 const PROCESS_DRAINING_VERSION = 5
 const OBSERVABLE_INVALIDATIONS_VERSION = 6
-const LATEST_VERSION = OBSERVABLE_INVALIDATIONS_VERSION
+const KEYED_REMINDERS_VERSION = 7
+const LATEST_VERSION = KEYED_REMINDERS_VERSION
 
 export async function installSchema(options: {
   connection: DatabaseConnection
@@ -211,6 +212,21 @@ export async function installSchema(options: {
       connection,
       table: table("schema_migrations"),
       version: RETRY_LINK_VERSION,
+      schemaIdentity,
+    })
+  }
+
+  if (!installedVersions.has(KEYED_REMINDERS_VERSION)) {
+    // operation already names the alarm, and a keyed reminder puts the key in
+    // that name. message_operation carries what should actually run. It is left
+    // null on existing rows, where the name is still the operation.
+    await connection.run(
+      `ALTER TABLE ${table("reminders")} ADD COLUMN ${family === "postgresql" ? "IF NOT EXISTS " : ""}message_operation ${family === "mysql" ? "VARCHAR(255)" : "TEXT"}`,
+    )
+    await recordMigration({
+      connection,
+      table: table("schema_migrations"),
+      version: KEYED_REMINDERS_VERSION,
       schemaIdentity,
     })
   }

--- a/test/dead-letters.test.ts
+++ b/test/dead-letters.test.ts
@@ -151,7 +151,7 @@ describe("schema migrations", () => {
     const broadcastColumns = await runtime.settings.database.connection((connection) =>
       connection.all<{ name: string }>("PRAGMA table_info(solid_objects_broadcasts)"),
     )
-    expect(versions.map(({ version }) => Number(version))).toEqual([1, 2, 3, 4, 5, 6])
+    expect(versions.map(({ version }) => Number(version))).toEqual([1, 2, 3, 4, 5, 6, 7])
     expect(deadLetterColumns.map(({ name }) => name)).toContain("retried_message_id")
     expect(broadcastColumns.map(({ name }) => name)).toContain("invalidations")
   })

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -27,7 +27,7 @@ describe("runtime doctor", () => {
     expect(check(report, "configuration").status).toBe("pass")
     expect(check(report, "schema")).toMatchObject({
       status: "pass",
-      details: { versions: [1, 2, 3, 4, 5, 6] },
+      details: { versions: [1, 2, 3, 4, 5, 6, 7] },
     })
     expect(check(report, "authorization").status).toBe("pass")
     expect(check(report, "database").status).toBe("pass")

--- a/test/outboxes.test.ts
+++ b/test/outboxes.test.ts
@@ -292,7 +292,7 @@ describe("reminders", () => {
     await Alarm.ref("obsolete-alarm").arm()
     await runtime.settings.database.connection((connection) =>
       connection.run(
-        `UPDATE ${runtime?.repository.table("reminders")} SET operation = 'removedOperation'`,
+        `UPDATE ${runtime?.repository.table("reminders")} SET message_operation = 'removedOperation'`,
       ),
     )
 

--- a/test/reminder-administration.test.ts
+++ b/test/reminder-administration.test.ts
@@ -40,7 +40,7 @@ describe("reminder administration", () => {
     await runtime.install()
     await ReminderActor.ref("one").arm({ at: new Date(Date.now() - 1_000).toISOString() })
     await runtime.settings.database.connection((connection) =>
-      connection.run(`UPDATE ${runtime?.repository.table("reminders")} SET operation = ?`, [
+      connection.run(`UPDATE ${runtime?.repository.table("reminders")} SET message_operation = ?`, [
         "removedOperation",
       ]),
     )
@@ -56,6 +56,7 @@ describe("reminder administration", () => {
     expect(paused.items[0]).toMatchObject({
       actorType: ReminderActor.actorType,
       actorId: "one",
+      name: "increment",
       operation: "removedOperation",
       status: "paused",
       errorName: "UnknownOperation",

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -36,6 +36,20 @@ class Counter extends Actor {
     }).increment!({ amount })
   }
 
+  armKeyed({ item, at }: { item: string; at: number }): void {
+    this.schedule({ at: new Date(at), key: item }).increment!({ amount: 1 })
+  }
+
+  armEmptyKey(): void {
+    this.schedule({ at: new Date("2030-01-02T03:04:05.000Z"), key: "" }).increment!({ amount: 1 })
+  }
+
+  armOversizedKey(): void {
+    this.schedule({ at: new Date("2030-01-02T03:04:05.000Z"), key: "k".repeat(200) }).increment!({
+      amount: 1,
+    })
+  }
+
   armUnknown(): void {
     this.schedule({ at: new Date("2030-01-02T03:04:05.000Z") }).missing!()
   }
@@ -299,6 +313,92 @@ describe("actor reminders", () => {
     })
     expect(Number(reminder?.run_at_ms)).toBe(new Date("2030-01-02T03:04:05.000Z").getTime())
     expect(Number(reminder?.interval_ms)).toBe(60_000)
+  })
+
+  it("gives each key its own alarm", async () => {
+    runtime = configuredRuntime()
+    await runtime.install()
+    const reference = Counter.ref("keyed")
+
+    await reference.armKeyed({ item: "a", at: new Date("2030-01-02T03:04:05.000Z").getTime() })
+    await reference.armKeyed({ item: "b", at: new Date("2030-01-03T03:04:05.000Z").getTime() })
+
+    const reminders = await runtime.settings.database.connection((connection) =>
+      connection.all<{ operation: string; message_operation: string | null }>(
+        `SELECT operation, message_operation FROM ${runtime?.repository.table("reminders")}
+         ORDER BY operation`,
+      ),
+    )
+    expect(reminders.map((reminder) => reminder.operation)).toEqual(["increment:a", "increment:b"])
+    expect(reminders.every((reminder) => reminder.message_operation === "increment")).toBe(true)
+  })
+
+  it("moves only the alarm whose key is scheduled again", async () => {
+    runtime = configuredRuntime()
+    await runtime.install()
+    const reference = Counter.ref("keyed-move")
+    const moved = new Date("2030-06-01T00:00:00.000Z").getTime()
+
+    await reference.armKeyed({ item: "a", at: new Date("2030-01-02T03:04:05.000Z").getTime() })
+    await reference.armKeyed({ item: "b", at: new Date("2030-01-03T03:04:05.000Z").getTime() })
+    await reference.armKeyed({ item: "a", at: moved })
+
+    const reminders = await runtime.settings.database.connection((connection) =>
+      connection.all<{ operation: string; run_at_ms: number | bigint }>(
+        `SELECT operation, run_at_ms FROM ${runtime?.repository.table("reminders")}
+         ORDER BY operation`,
+      ),
+    )
+    expect(reminders).toHaveLength(2)
+    expect(Number(reminders[0]?.run_at_ms)).toBe(moved)
+    expect(Number(reminders[1]?.run_at_ms)).toBe(new Date("2030-01-03T03:04:05.000Z").getTime())
+  })
+
+  it("keeps naming an unkeyed alarm for its operation", async () => {
+    runtime = configuredRuntime()
+    await runtime.install()
+
+    await Counter.ref("unkeyed").arm({ amount: 7 })
+
+    const reminder = await runtime.settings.database.connection((connection) =>
+      connection.get<{ operation: string; message_operation: string | null }>(
+        `SELECT operation, message_operation FROM ${runtime?.repository.table("reminders")}`,
+      ),
+    )
+    expect(reminder?.operation).toBe("increment")
+    expect(reminder?.message_operation).toBe("increment")
+  })
+
+  it("runs a keyed alarm against the operation it was scheduled with", async () => {
+    runtime = configuredRuntime()
+    await runtime.install()
+    const reference = Counter.ref("keyed-delivery")
+    await reference.armKeyed({ item: "a", at: Date.now() - 1_000 })
+
+    expect(await runtime.reminderScheduler().runOnce()).toBe(1)
+    await runtime.worker().runUntilIdle()
+
+    expect(await reference.increment({ amount: 0 })).toBe(1)
+  })
+
+  it("refuses an empty key", async () => {
+    runtime = configuredRuntime({ maxAttempts: 1 })
+    await runtime.install()
+    const message = await Counter.ref("keyed-empty").send.armEmptyKey()
+
+    await runtime.worker().runUntilIdle()
+
+    expect(await message.status()).toBe("dead")
+  })
+
+  it("refuses a key longer than the name allows", async () => {
+    runtime = configuredRuntime({ maxAttempts: 1 })
+    await runtime.install()
+    const message = await Counter.ref("keyed-long").send.armOversizedKey()
+
+    await runtime.worker().runUntilIdle()
+
+    expect(await message.status()).toBe("dead")
   })
 
   it("rejects unknown reminder messages before persistence", async () => {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -45,7 +45,13 @@ class Counter extends Actor {
   }
 
   armOversizedKey(): void {
-    this.schedule({ at: new Date("2030-01-02T03:04:05.000Z"), key: "k".repeat(200) }).increment!({
+    this.schedule({ at: new Date("2030-01-02T03:04:05.000Z"), key: "k".repeat(300) }).increment!({
+      amount: 1,
+    })
+  }
+
+  armSeparatorKey(): void {
+    this.schedule({ at: new Date("2030-01-02T03:04:05.000Z"), key: "group:7" }).increment!({
       amount: 1,
     })
   }
@@ -391,7 +397,22 @@ describe("actor reminders", () => {
     expect(await message.status()).toBe("dead")
   })
 
-  it("refuses a key longer than the name allows", async () => {
+  it("allows a key to hold the separator, since the operation may not", async () => {
+    runtime = configuredRuntime()
+    await runtime.install()
+
+    await Counter.ref("keyed-separator").armSeparatorKey()
+
+    const reminder = await runtime.settings.database.connection((connection) =>
+      connection.get<{ operation: string; message_operation: string | null }>(
+        `SELECT operation, message_operation FROM ${runtime?.repository.table("reminders")}`,
+      ),
+    )
+    expect(reminder?.operation).toBe("increment:group:7")
+    expect(reminder?.message_operation).toBe("increment")
+  })
+
+  it("refuses a composed name longer than the database holds", async () => {
     runtime = configuredRuntime({ maxAttempts: 1 })
     await runtime.install()
     const message = await Counter.ref("keyed-long").send.armOversizedKey()


### PR DESCRIPTION
Adds `key` to `schedule`, so one actor can hold an alarm per item it is waiting on. This is the Node half of cardmagic/solid_objects#41.

## Why

A reminder is one alarm per actor and name, and the name was the operation. An actor waiting on several things could therefore hold only one alarm: arming one per item kept the last and dropped the rest, silently.

```typescript
// Wrong. Every entry overwrites the previous entry's alarm.
add({ entry }: { entry: Entry }): void {
  this.entries = [...this.entries, entry]
  this.schedule({ at: new Date(entry.waitUntil) }).deliver!()
}
```

The workaround is to keep entries sorted, arm one alarm for the earliest, drain everything due when it fires, and re-arm. That works, and is still the better choice for a large queue of interchangeable items, but every actor holding scheduled work has to write it. In one application I have three actors doing exactly that, the third copied verbatim from the first.

## What changes

```typescript
add({ entry }: { entry: Entry }): void {
  this.entries = [...this.entries, entry]
  this.schedule({ at: new Date(entry.waitUntil), key: entry.id }).deliver!()
}
```

Two entries now leave two reminders. Scheduling the same key again moves that item's alarm and leaves the others alone, so a keyed reminder is as safe to re-arm from a handler that may run twice as an unkeyed one.

## Schema

The `operation` column already **named** the alarm, since the unique key is `(instance_id, operation)`. It keeps that job, and a new nullable `message_operation` carries what should actually run.

That means the migration adds a column and backfills nothing: on an existing row `message_operation` is null and the name is still the operation, which is exactly the old behaviour. Dispatch reads `message_operation ?? operation` in the two places that resolve a reminder to a message.

Schema version 7. Following this repository's convention, the column is added by the migration rather than the base DDL, so a fresh install takes the same path.

## Administration

`reminders.all()` now reports both: `name` is the alarm, `operation` is what it runs. Previously `operation` was the only field and it was the name; for a keyed alarm that would have read as `"deliver:item-7"` and been misleading about what runs.

Two existing tests rewrote the `operation` column to simulate a reminder whose message no longer exists. They now rewrite `message_operation`, which is the column that decides dispatch. The behaviour they cover is unchanged; the column that expresses it moved.

## Differences from the Ruby PR

Ruby already had separate `name` and `operation` columns, so it needed no migration. Node had one column doing both jobs, so it gains `message_operation`. The public API is the same shape in both: `key` on the schedule options, composed into the name as `operation:key`, with the same 128-character bound.

## Testing

244 tests, 0 failures. Typecheck, format, parameter-style and documentation checks all clean.

New coverage: each key gets its own alarm; scheduling one key again moves only that alarm; an unkeyed alarm is still named for its operation; a keyed alarm runs the operation it was scheduled with; and both key bounds are refused.