### PR TITLE
Name the package, then say what it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# Durable Objects for Node, backed by your existing SQL database
+# Solid Objects JS
 
 [![CI](https://github.com/cardmagic/solid-objects-js/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/cardmagic/solid-objects-js/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/solid-objects)](https://www.npmjs.com/package/solid-objects)
+
+Self-hosted, distributed Durable Objects in Node without a daemon using your
+existing SQL database.
 
 Build addressable TypeScript objects with serialized calls and durable state
 using SQLite, PostgreSQL, or MySQL, without deploying to Cloudflare.


### PR DESCRIPTION
Renames the README heading and adds a tagline under it.

Before:

```markdown
# Durable Objects for Node, backed by your existing SQL database

[badges]

Build addressable TypeScript objects with serialized calls and durable state
using SQLite, PostgreSQL, or MySQL, without deploying to Cloudflare.
```

After:

```markdown
# Solid Objects JS

[badges]

Self-hosted, distributed Durable Objects in Node without a daemon using your
existing SQL database.

Build addressable TypeScript objects with serialized calls and durable state
using SQLite, PostgreSQL, or MySQL, without deploying to Cloudflare.
```

The heading was a description, so the package had no name at the top of its own README and anything rendering the first heading led with a sentence instead of the name. The name goes there now, and the description follows as the first line of prose.

The existing paragraph is kept rather than replaced; it says what you build, where the new line says what the package is.

## Checks

`format:check`, `check:parameters` and `check:documentation` all pass, and nothing else in the repository referenced the old heading.