### PR TITLE
Put keyed reminders in the release they ship in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.13.2 - 2026-08-17
 
 - Accept a `key` on `schedule`, naming a reminder for the item it is waiting
   on rather than for its operation, so one actor can hold an alarm per queued
@@ -10,9 +10,6 @@
   `message_operation` column to the reminders table, left null on existing rows.
   The composed name is bounded by the 255 characters MySQL holds it in, checked
   on the name rather than the key alone.
-
-## 0.13.2 - 2026-08-16
-
 - Add an authorized `runtime.administration.processes()` query for inspecting
   live and stale process rows through the runtime's database adapter.
 - Document rolling-deployment overlap as a reason for the polling-only warning.


### PR DESCRIPTION
Folds the `Unreleased` changelog entry into `0.13.2` and dates it for the day it goes out.

## Why

`0.13.2` has a changelog section and `package.json` already says `0.13.2`, but it was never published — npm is still on `0.13.1`. Keyed reminders then landed and went under `Unreleased`, above a release that had not happened.

Read from the outside that says 0.13.2 shipped and keyed reminders are waiting for something later, when in fact they go out together.

No version bump: `package.json` is already `0.13.2` and `pack:check` produces `solid-objects-0.13.2.tgz`.

## Manual QA on merged main

I drove keyed reminders through a real actor with the scheduler and worker running, rather than asserting on intents:

```
1. three items -> 3 alarms: [ 'launch:alpha', 'launch:bravo', 'launch:charlie' ]
   dispatch operations: [ 'launch' ]
2. due alarms fired: 2 launched: [ 'alpha', 'bravo' ]
   pending entry kept: [ 'charlie' ]
3. remaining armed alarm: [ 'launch:charlie' ]
4. rescheduling one key moved only it: at= true total alarms= 3
5. a key holding colons works: true dispatch= launch
```

### Upgrading a database that already holds reminders

This is the part I most wanted to see for real, since the release adds a column and CI mostly exercises fresh installs. I took a database back to what a pre-keyed release left behind — dropping `message_operation` and the record of migration 7 — with an alarm already armed in it, then reopened it:

```
1. row as an older release left it: { operation: 'ring' }
2. versions after upgrade: [1,2,3,4,5,6,7]
3. the old null-dispatch alarm still fired: 1 { fired: [ 'plain' ] }
4. rows after upgrade: [{"name":"ring","dispatch":null},{"name":"ring:item-9","dispatch":"ring"}]
```

The alarm written before the column existed still fires after the upgrade, which is the `message_operation ?? operation` fallback doing its job on a real row rather than in a unit test, and a keyed alarm then joins it in the same table.

248 tests, 0 failures. Typecheck, format, parameter-style, documentation and `pack:check` all clean.

## One flake, not from this change

`test/lifecycle.test.ts > renews an idle cached activation before its lease expires` failed twice while I was running QA in parallel, expecting `activation: 1` and getting `activation: 2`. It is a lease-renewal timing assertion, and that file runs with `reminderSchedulerCount: 0`, so reminders are not involved. On a quiet machine it passed 6 runs out of 6. Worth knowing it is load-sensitive; not worth blocking on.

## Note

The matching Ruby release is cardmagic/solid_objects#43.
