### PR TITLE
ci: add 15-minute timeout to each job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
@@ -29,6 +30,7 @@ jobs:
 
   floor:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
@@ -43,6 +45,7 @@ jobs:
 
   postgresql:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -74,6 +77,7 @@ jobs:
 
   mysql:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +110,7 @@ jobs:
 
   browser:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
@@ -118,6 +123,7 @@ jobs:
 
   redis:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       redis:
         image: redis:7
@@ -143,6 +149,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [quality, floor, postgresql, mysql, browser, redis]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Why

CI on main shows as not passing. The last two runs on main were cancelled after 6 hours.

Root cause: the `browser` job ran `playwright install --with-deps chromium`. That step calls `apt-get update`. The mirror `azure.archive.ubuntu.com` was unreachable on 2026-08-19, and apt stalled with no limit. No job had a `timeout-minutes` value, so GitHub killed the job at the 6-hour default.

## What

Add `timeout-minutes: 15` to every job. A normal run completes in 1 to 3 minutes. With this limit, a hung job fails in 15 minutes, and a rerun costs minutes and not hours.