### PR TITLE
docs: point links at renamed Ruby repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ and [Configuration](docs/configuration.md).
 ## Design provenance
 
 Solid Objects JS is a Node.js and TypeScript implementation. The Ruby
-[`solid_objects`](https://github.com/cardmagic/solid_objects) design informed
+[`solid_objects`](https://github.com/cardmagic/solid-objects-ruby) design informed
 it. It began at the `0.12` capability generation, because the first
 implementation targeted the Ruby `0.12` contract. That number does not represent
 twelve earlier JavaScript release generations.

--- a/compatibility/ruby.yml
+++ b/compatibility/ruby.yml
@@ -1,4 +1,4 @@
-ruby_repository: https://github.com/cardmagic/solid_objects
+ruby_repository: https://github.com/cardmagic/solid-objects-ruby
 ruby_version: 0.12.0
 ruby_commit: a01b6f5
 npm_version: 0.12.0


### PR DESCRIPTION
The Ruby gem's GitHub repository moved from cardmagic/solid_objects to cardmagic/solid-objects-ruby. The gem name stays solid_objects. Update the README and the compatibility ledger so links skip the redirect.