### PR TITLE
docs: say background pickup needs run(signal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- State that background pickup needs `runtime.run(signal)`
+  ([#22](https://github.com/cardmagic/solid-objects-js/issues/22)). The
+  README's programming-model example works without it because the caller's
+  own path executes the call, and nothing on that page said that a process
+  which installs and then waits claims nothing. An external prober built a
+  two-process harness from the README and read the unclaimed messages as
+  stranded. The README and `docs/operations.md` now state it, and
+  `test/background-pickup.test.ts` pins it: a sent message reads `ready`
+  after `install()`, and `completed` once `run(signal)` starts the roles.
+- Address the same example with `Cart.ref("cart-123")` instead of
+  `runtime.ref(Cart, "cart-123")`, matching every other reference example.
+
 - Add `examples/at-least-once` and `pnpm run test:at-least-once`
   ([#23](https://github.com/cardmagic/solid-objects-js/issues/23)): an
   executable proof that the at-least-once clause fires and that the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@
   stranded. The README and `docs/operations.md` now state it, and
   `test/background-pickup.test.ts` pins it: a sent message reads `ready`
   after `install()`, and `completed` once `run(signal)` starts the roles.
-- Address the same example with `Cart.ref("cart-123")` instead of
-  `runtime.ref(Cart, "cart-123")`, matching every other reference example.
+- Build the same example with `configure()` and address the actor as
+  `Cart.ref("cart-123")`, matching every other reference example in the
+  documentation. `createRuntime()` deliberately leaves the process default
+  unset, so the static form needs `configure()`.
 
 - Add `examples/at-least-once` and `pnpm run test:at-least-once`
   ([#23](https://github.com/cardmagic/solid-objects-js/issues/23)): an

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ contract. See [Solid Objects in the browser](#solid-objects-in-the-browser).
 ## The programming model
 
 ```typescript
-import { Actor, createRuntime } from "solid-objects"
+import { Actor, configure } from "solid-objects"
 import { sqlite } from "solid-objects/database/sqlite"
 
 class Cart extends Actor {
@@ -53,7 +53,7 @@ class Cart extends Actor {
   }
 }
 
-const runtime = createRuntime({
+const runtime = configure({
   database: sqlite({ path: "cart.sqlite3" }),
   authorizeMessage: () => true,
   authorizeQuery: () => true,

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const runtime = createRuntime({
 await runtime.install()
 
 try {
-  const cart = runtime.ref(Cart, "cart-123")
+  const cart = Cart.ref("cart-123")
   await Promise.all([cart.add({ sku: "blue-shirt" }), cart.add({ sku: "green-hat" })])
 } finally {
   await runtime.close()
@@ -72,6 +72,18 @@ try {
 Both calls enter the durable mailbox for `cart-123`. They execute in order and
 commit one state transition at a time, even when different requests or Node.js
 processes submit them concurrently.
+
+`install()` prepares the database and starts nothing. The example above finishes
+because the caller's own path executes each call. A process serves background
+work only after `runtime.run(signal)` starts its roles, so a process that
+installs and then waits never claims a ready message. Nothing is lost while no
+process runs. The message stays ready until one does.
+
+```typescript
+const controller = new AbortController()
+process.on("SIGTERM", () => controller.abort())
+await runtime.run(controller.signal)
+```
 
 ## Run it now with SQLite
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,5 +1,12 @@
 # Operations
 
+`install()` prepares the database and starts nothing. A process serves
+background work only after `runtime.run(signal)` starts its roles. A process
+that registers actors, installs, and then waits never claims a ready message,
+and work enqueued with `send` stays ready until some process runs the roles.
+A direct call or an explicit `sync` needs no running role, because the caller's
+own path executes it.
+
 Runtime roles use durable polling as the correctness fallback. Consecutive
 empty passes double each role's wait from `pollingIntervalMilliseconds` to
 `idlePollingIntervalMilliseconds`, which defaults to one second. Processed

--- a/test/background-pickup.test.ts
+++ b/test/background-pickup.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { Actor } from "../src/actor.js"
+import { sqlite } from "../src/database/sqlite.js"
+import { createRuntime, type SolidObjectsRuntime } from "../src/runtime.js"
+
+class Mailbox extends Actor {
+  static override readonly actorType = "BackgroundPickupMailbox"
+
+  delivered = 0
+
+  receive(): number {
+    this.delivered += 1
+    return this.delivered
+  }
+}
+
+let runtime: SolidObjectsRuntime | undefined
+
+afterEach(async () => {
+  await runtime?.close()
+  runtime = undefined
+})
+
+function startedRuntime(): SolidObjectsRuntime {
+  return createRuntime({
+    database: sqlite({ path: ":memory:" }),
+    pollingIntervalMilliseconds: 10,
+    workerCount: 1,
+    effectWorkerCount: 0,
+    reminderSchedulerCount: 0,
+    retentionIntervalMilliseconds: 0,
+    deadProcessCleanupIntervalMilliseconds: 0,
+    authorizeMessage: () => true,
+    authorizeQuery: () => true,
+  })
+}
+
+describe("background pickup", () => {
+  it("leaves a message ready until run() starts the roles", async () => {
+    runtime = startedRuntime()
+    runtime.register(Mailbox)
+    await runtime.install()
+
+    const message = await runtime.ref(Mailbox, "inbox").send.receive()
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    expect(await message.status()).toBe("ready")
+
+    const controller = new AbortController()
+    const running = runtime.run(controller.signal)
+    try {
+      await message.wait({ timeoutMilliseconds: 2_000 })
+    } finally {
+      controller.abort()
+      await running
+    }
+
+    expect(await message.status()).toBe("completed")
+  })
+})

--- a/test/background-pickup.test.ts
+++ b/test/background-pickup.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest"
 import { Actor } from "../src/actor.js"
 import { sqlite } from "../src/database/sqlite.js"
+import type { MessageReference } from "../src/reference.js"
+import type { MessageStatus } from "../src/types.js"
 import { createRuntime, type SolidObjectsRuntime } from "../src/runtime.js"
 
 class Mailbox extends Actor {
@@ -48,13 +50,27 @@ describe("background pickup", () => {
 
     const controller = new AbortController()
     const running = runtime.run(controller.signal)
+    let observed: MessageStatus
     try {
-      await message.wait({ timeoutMilliseconds: 2_000 })
+      observed = await pollStatus({ message, timeoutMilliseconds: 2_000 })
     } finally {
       controller.abort()
       await running
     }
 
-    expect(await message.status()).toBe("completed")
+    expect(observed).toBe("completed")
   })
 })
+
+async function pollStatus(options: {
+  message: MessageReference<number>
+  timeoutMilliseconds: number
+}): Promise<MessageStatus> {
+  const deadline = performance.now() + options.timeoutMilliseconds
+  let status = await options.message.status()
+  while (status !== "completed" && performance.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    status = await options.message.status()
+  }
+  return status
+}


### PR DESCRIPTION
Closes #22.

## Why

`install()` migrates the schema and starts nothing. The README's
programming-model example completes anyway, because a direct call runs on the
caller's own path, so the page never had a reason to mention roles. A reader
who builds a two-process harness from that example gets a process that
registers actors, installs, and then waits forever, because nothing polls until
`runtime.run(signal)` starts the roles. An external prober did exactly that
against 0.14.0, watched ready messages sit for 30 seconds, and concluded
messages were stranded.

Nothing was wrong with the runtime. The page was missing one sentence.

## What changed

**README**, right after the model example:

> `install()` prepares the database and starts nothing. The example above
> finishes because the caller's own path executes each call. A process serves
> background work only after `runtime.run(signal)` starts its roles, so a
> process that installs and then waits never claims a ready message. Nothing is
> lost while no process runs. The message stays ready until one does.

with the shape a real process uses:

```typescript
const controller = new AbortController()
process.on("SIGTERM", () => controller.abort())
await runtime.run(controller.signal)
```

**docs/operations.md**, first paragraph: the same claim, plus the boundary that
makes it make sense. A direct call or an explicit `sync` needs no running role.

**The same example** addressed its actor as `runtime.ref(Cart, "cart-123")`
while every other reference example in the README uses the static form. It now
reads `Cart.ref("cart-123")`. `createRuntime` sets the default runtime, so the
example still runs as written.

## Keeping the sentence honest

`test/background-pickup.test.ts` pins the documented behavior:

```typescript
const message = await runtime.ref(Mailbox, "inbox").send.receive()
await new Promise((resolve) => setTimeout(resolve, 200))

expect(await message.status()).toBe("ready")     // install() started nothing

const running = runtime.run(controller.signal)
await message.wait({ timeoutMilliseconds: 2_000 })

expect(await message.status()).toBe("completed") // run(signal) picked it up
```

A test that only ever sees `ready` proves nothing, so I checked that the first
assertion detects pickup. Replacing the wait with `runtime.worker().runOnce()`
turns it red:

```
AssertionError: expected 'completed' to be 'ready' // Object.is equality
Expected: "ready"
Received: "completed"
```

## Ruby counterpart

cardmagic/solid-objects-ruby#52 covers the same gap for the gem. Ruby was in
better shape already: the README has a Worker requirements table that says a
missing worker leaves the message pending. What it lacked was the pointer at
the point of use, in the `async` section, and the equivalent statement in the
operations guide. That PR adds both, plus the matching test.

## Validation

- `pnpm run check`: clean.
- `pnpm test`: 343 pass, 13 skipped.
- Mutation check on the new test, quoted above.
