### PR TITLE
release: bump to 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.14.2 - 2026-08-24
 
 - State that background pickup needs `runtime.run(signal)`
   ([#22](https://github.com/cardmagic/solid-objects-js/issues/22)). The
@@ -15,7 +15,6 @@
   `Cart.ref("cart-123")`, matching every other reference example in the
   documentation. `createRuntime()` deliberately leaves the process default
   unset, so the static form needs `configure()`.
-
 - Add `examples/at-least-once` and `pnpm run test:at-least-once`
   ([#23](https://github.com/cardmagic/solid-objects-js/issues/23)): an
   executable proof that the at-least-once clause fires and that the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-objects",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Race-free realtime state per application identity, backed by your SQL database",
   "type": "module",
   "license": "MIT",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.14.1"
+export const VERSION = "0.14.2"


### PR DESCRIPTION
Documentation-only release. No runtime code changed.

## Why now

The package ships `README.md` and `docs/` inside the tarball, and npmjs.com
renders that README. The fix for #22 merged in #27, but published 0.14.1 still
shows the broken guidance:

```
published 0.14.1 README:  const cart = runtime.ref(Cart, "cart-123")
                          "installs and then waits" → 0 occurrences
```

That is the exact page the external prober read before concluding messages
were stranded, so leaving it unpublished leaves the report unaddressed for
anyone arriving through npm. The gem does not have this gap: solid_objects
0.14.1 shipped its equivalent docs fix on RubyGems.

## What ships

- The `run(signal)` statement in `README.md` and `docs/operations.md` (#22).
- The model example built with `configure()` and addressed as
  `Cart.ref("cart-123")`, which is the form that actually runs.
- `examples/at-least-once` and `pnpm run test:at-least-once` (#23).

Verified in the packed tarball rather than the working tree:

```
README: "installs and then waits" → 1
README: const cart = Cart.ref("cart-123")
docs/operations.md: "starts nothing" → 1
package.json: "version": "0.14.2"
```

## Validation

Full release gate list from `docs/releasing.md`, all passing locally:
`format:check`, `check`, `test:coverage`, `build`, `pack:check`,
`test:package`, `test:recovery`, `test:at-least-once`,
`pnpm audit --audit-level=high` (no known vulnerabilities), and
`test:browser` (9 passed). The PostgreSQL, MySQL, and Redis matrices run here
in CI.