### PR TITLE
Move Cloudflare note below the use case list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 
 **Open Source Durable Objects in your Node app.**
 
-Deploying on Cloudflare? The [Durable Objects backend](docs/cloudflare.md) runs
-the same actor API on Workers, with durable mailboxes, alarms, and browser
-subscriptions. Start with the [Cloudflare example](examples/cloudflare/README.md).
-
 In a shopping cart, paying twice at the same time is a big problem. The payment provider might time out, and your Node site could be restarting before recovery finishes.
 
 To deal with this safely, you often need logic scattered between 7-10 files like database row locks, Redis locks, delayed jobs, retries, and cleanup code to keep that process straight. They are not all large, but they must agree about the same payment state and failure rules. That coordination is the difficult part.
@@ -27,6 +23,10 @@ Solid Object JavaScript Actors elegantly fit anything where one identifiable thi
 - Collaborative documents
 
 And so much more.
+
+Deploying on Cloudflare? The [Durable Objects backend](docs/cloudflare.md) runs
+the same actor API on Workers, with durable mailboxes, alarms, and browser
+subscriptions. Start with the [Cloudflare example](examples/cloudflare/README.md).
 
 ## Contents
 


### PR DESCRIPTION
## Summary

The Cloudflare Durable Objects note sat directly under the tagline, before the reader knew what Solid Objects does. This moves it below the "And so much more." line, after the problem statement and the use case list.

## Changes

- Move the Cloudflare paragraph from line 8 to just above the Contents section.

No text changes. Only the position changes.